### PR TITLE
Context values compat

### DIFF
--- a/Compat/WithGraphQLContextValuesTrait.php
+++ b/Compat/WithGraphQLContextValuesTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Magento\ReviewGraphQl\Compat;
+
+use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
+use Magento\Store\Api\Data\StoreInterface;
+use Magento\Store\Model\StoreManagerInterface;
+
+trait WithGraphQLContextValuesTrait
+{
+  /**
+   * The store parameter in GraphQL context appeared in 2.3.3
+   * and before https://github.com/magento/graphql-ce/pull/742/ there
+   * was no way to add extra parameters to the context.
+   *
+   * This trait provides a fallback implementation for earlier Magento versions.
+   *
+   * @param ContextInterface $context
+   * @param StoreManagerInterface $storeManager
+   * @return StoreInterface
+   */
+  protected function getStore(
+    ContextInterface $context,
+    StoreManagerInterface $storeManager
+  ): StoreInterface {
+    $extension = $context->getExtensionAttributes();
+    if (method_exists($extension, 'getStore')) {
+      return $extension->getStore();
+    }
+    return $storeManager->getStore();
+  }
+}

--- a/Compat/WithGraphQLContextValuesTrait.php
+++ b/Compat/WithGraphQLContextValuesTrait.php
@@ -6,14 +6,18 @@ use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\StoreManagerInterface;
 
+/**
+ * Before https://github.com/magento/graphql-ce/pull/742/ there
+ * was no way to add extra parameters to the context.
+ *
+ * This trait provides a fallback implementation to get values
+ * now in the context, but for earlier Magento versions.
+ */
 trait WithGraphQLContextValuesTrait
 {
   /**
    * The store parameter in GraphQL context appeared in 2.3.3
-   * and before https://github.com/magento/graphql-ce/pull/742/ there
-   * was no way to add extra parameters to the context.
-   *
-   * This trait provides a fallback implementation for earlier Magento versions.
+   * see Magento\StoreGraphQl\Model\Context\AddStoreInfoToContext
    *
    * @param ContextInterface $context
    * @param StoreManagerInterface $storeManager
@@ -28,5 +32,23 @@ trait WithGraphQLContextValuesTrait
       return $extension->getStore();
     }
     return $storeManager->getStore();
+  }
+
+  /**
+   * The isCustomer parameter in GraphQL context appeared in 2.3.3
+   * see Magento\CustomerGraphQl\Model\Context\AddUserInfoToContext
+   *
+   * @param ContextInterface $context
+   * @return bool
+   */
+  protected function getIsCustomer(ContextInterface $context): bool
+  {
+    $extension = $context->getExtensionAttributes();
+    if (method_exists($extension, 'getIsCustomer')) {
+      return  $extension->getIsCustomer();
+    }
+
+    $userId = $context->getUserId();
+    return !empty($userId);
   }
 }

--- a/Model/Resolver/CreateProductReview.php
+++ b/Model/Resolver/CreateProductReview.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 declare(strict_types=1);
 
 namespace Magento\ReviewGraphQl\Model\Resolver;
@@ -16,15 +18,19 @@ use Magento\Framework\GraphQl\Query\ResolverInterface;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 use Magento\Review\Helper\Data as ReviewHelper;
 use Magento\Review\Model\Review\Config as ReviewsConfig;
+use Magento\ReviewGraphQl\Compat\WithGraphQLContextValuesTrait;
 use Magento\ReviewGraphQl\Mapper\ReviewDataMapper;
 use Magento\ReviewGraphQl\Model\Review\AddReviewToProduct;
 use Magento\Store\Api\Data\StoreInterface;
+use Magento\Store\Model\StoreManagerInterface;
 
 /**
  * Create product review resolver
  */
 class CreateProductReview implements ResolverInterface
 {
+    use WithGraphQLContextValuesTrait;
+
     /**
      * @var ReviewHelper
      */
@@ -46,6 +52,11 @@ class CreateProductReview implements ResolverInterface
     private $reviewsConfig;
 
     /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
      * @param AddReviewToProduct $addReviewToProduct
      * @param ReviewDataMapper $reviewDataMapper
      * @param ReviewHelper $reviewHelper
@@ -55,13 +66,15 @@ class CreateProductReview implements ResolverInterface
         AddReviewToProduct $addReviewToProduct,
         ReviewDataMapper $reviewDataMapper,
         ReviewHelper $reviewHelper,
-        ReviewsConfig $reviewsConfig
+        ReviewsConfig $reviewsConfig,
+        StoreManagerInterface $storeManager
     ) {
 
         $this->addReviewToProduct = $addReviewToProduct;
         $this->reviewDataMapper = $reviewDataMapper;
         $this->reviewHelper = $reviewHelper;
         $this->reviewsConfig = $reviewsConfig;
+        $this->storeManager = $storeManager;
     }
 
     /**
@@ -110,7 +123,7 @@ class CreateProductReview implements ResolverInterface
             'detail' => $input['text'],
         ];
         /** @var StoreInterface $store */
-        $store = $context->getExtensionAttributes()->getStore();
+        $store = $this->getStore($context, $this->storeManager);
         $review = $this->addReviewToProduct->execute($data, $ratings, $sku, $customerId, (int) $store->getId());
 
         return ['review' => $this->reviewDataMapper->map($review)];

--- a/Model/Resolver/CreateProductReview.php
+++ b/Model/Resolver/CreateProductReview.php
@@ -107,7 +107,7 @@ class CreateProductReview implements ResolverInterface
         $input = $args['input'];
         $customerId = null;
 
-        if (false !== $context->getExtensionAttributes()->getIsCustomer()) {
+        if (false !== $this->getIsCustomer($context)) {
             $customerId = (int) $context->getUserId();
         }
 

--- a/Model/Resolver/Customer/Reviews.php
+++ b/Model/Resolver/Customer/Reviews.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 declare(strict_types=1);
 
 namespace Magento\ReviewGraphQl\Model\Resolver\Customer;
@@ -14,6 +16,7 @@ use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
 use Magento\Framework\GraphQl\Query\Resolver\Value;
 use Magento\Framework\GraphQl\Query\ResolverInterface;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\ReviewGraphQl\Compat\WithGraphQLContextValuesTrait;
 use Magento\ReviewGraphQl\Model\DataProvider\AggregatedReviewsDataProvider;
 use Magento\ReviewGraphQl\Model\DataProvider\CustomerReviewsDataProvider;
 
@@ -22,6 +25,8 @@ use Magento\ReviewGraphQl\Model\DataProvider\CustomerReviewsDataProvider;
  */
 class Reviews implements ResolverInterface
 {
+    use WithGraphQLContextValuesTrait;
+
     /**
      * @var CustomerReviewsDataProvider
      */
@@ -67,7 +72,7 @@ class Reviews implements ResolverInterface
         array $value = null,
         array $args = null
     ) {
-        if (false === $context->getExtensionAttributes()->getIsCustomer()) {
+        if (false === $this->getIsCustomer($context)) {
             throw new GraphQlAuthorizationException(__('The current customer isn\'t authorized.'));
         }
 

--- a/Model/Resolver/Product/RatingSummary.php
+++ b/Model/Resolver/Product/RatingSummary.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 declare(strict_types=1);
 
 namespace Magento\ReviewGraphQl\Model\Resolver\Product;
@@ -16,13 +18,17 @@ use Magento\Framework\GraphQl\Query\ResolverInterface;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 use Magento\Review\Model\Review\Config as ReviewsConfig;
 use Magento\Review\Model\Review\SummaryFactory;
+use Magento\ReviewGraphQl\Compat\WithGraphQLContextValuesTrait;
 use Magento\Store\Api\Data\StoreInterface;
+use Magento\Store\Model\StoreManagerInterface;
 
 /**
  * Average rating for the product
  */
 class RatingSummary implements ResolverInterface
 {
+    use WithGraphQLContextValuesTrait;
+
     /**
      * @var SummaryFactory
      */
@@ -34,15 +40,23 @@ class RatingSummary implements ResolverInterface
     private $reviewsConfig;
 
     /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
      * @param SummaryFactory $summaryFactory
      * @param ReviewsConfig $reviewsConfig
+     * @param StoreManagerInterface $storeManager
      */
     public function __construct(
         SummaryFactory $summaryFactory,
-        ReviewsConfig $reviewsConfig
+        ReviewsConfig $reviewsConfig,
+        StoreManagerInterface $storeManager
     ) {
         $this->summaryFactory = $summaryFactory;
         $this->reviewsConfig = $reviewsConfig;
+        $this->storeManager = $storeManager;
     }
 
     /**
@@ -76,7 +90,7 @@ class RatingSummary implements ResolverInterface
         }
 
         /** @var StoreInterface $store */
-        $store = $context->getExtensionAttributes()->getStore();
+        $store = $this->getStore($context, $this->storeManager);
 
         /** @var Product $product */
         $product = $value['model'];

--- a/Model/Resolver/ProductReviewRatingsMetadata.php
+++ b/Model/Resolver/ProductReviewRatingsMetadata.php
@@ -18,13 +18,17 @@ use Magento\Review\Model\ResourceModel\Rating\Collection as RatingCollection;
 use Magento\Review\Model\ResourceModel\Rating\CollectionFactory;
 use Magento\Review\Model\Review;
 use Magento\Review\Model\Review\Config as ReviewsConfig;
+use Magento\ReviewGraphQl\Compat\WithGraphQLContextValuesTrait;
 use Magento\Store\Api\Data\StoreInterface;
+use Magento\Store\Model\StoreManagerInterface;
 
 /**
  * Resolve data review rating metadata
  */
 class ProductReviewRatingsMetadata implements ResolverInterface
 {
+    use WithGraphQLContextValuesTrait;
+
     /**
      * @var CollectionFactory
      */
@@ -36,13 +40,22 @@ class ProductReviewRatingsMetadata implements ResolverInterface
     private $reviewsConfig;
 
     /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
      * @param CollectionFactory $ratingCollectionFactory
      * @param ReviewsConfig $reviewsConfig
      */
-    public function __construct(CollectionFactory $ratingCollectionFactory, ReviewsConfig $reviewsConfig)
-    {
+    public function __construct(
+        CollectionFactory $ratingCollectionFactory,
+        ReviewsConfig $reviewsConfig,
+        StoreManagerInterface $storeManager
+    ) {
         $this->ratingCollectionFactory = $ratingCollectionFactory;
         $this->reviewsConfig = $reviewsConfig;
+        $this->storeManager = $storeManager;
     }
 
     /**
@@ -71,7 +84,7 @@ class ProductReviewRatingsMetadata implements ResolverInterface
 
         $items = [];
         /** @var StoreInterface $store */
-        $store = $context->getExtensionAttributes()->getStore();
+        $store = $this->getStore($context, $this->storeManager);
 
         /** @var RatingCollection $ratingCollection */
         $ratingCollection = $this->ratingCollectionFactory->create();


### PR DESCRIPTION
This PR introduces a compatibility layer so the module could work with pre 2.3.3 versions.

See https://github.com/magento/graphql-ce/pull/742/ for the change that was introduced in 2.3.3 and this module relied upon.